### PR TITLE
feat: add priority scheduling and process state queries

### DIFF
--- a/src/core/CoreSystem.cpp
+++ b/src/core/CoreSystem.cpp
@@ -1,0 +1,81 @@
+#include "core/CoreSystem.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace trinity {
+
+CoreSystem::CoreSystem() = default;
+
+CoreSystem::~CoreSystem() { stop(); }
+
+void CoreSystem::initialize() {
+    // Placeholder for future initialization logic.
+}
+
+void CoreSystem::start() {
+    running_ = true;
+    schedulerThread_ = std::thread(&CoreSystem::schedulerLoop, this);
+}
+
+void CoreSystem::stop() {
+    {
+        std::lock_guard<std::mutex> lock(queueMutex_);
+        running_ = false;
+    }
+    cv_.notify_all();
+    if (schedulerThread_.joinable()) {
+        schedulerThread_.join();
+    }
+}
+
+void CoreSystem::addProcess(std::function<void()> task, int priority, std::string name) {
+    std::lock_guard<std::mutex> lock(queueMutex_);
+    int pid = nextPid_++;
+    Process proc{pid, priority, ProcessState::READY, std::move(name), std::move(task)};
+
+    auto it = std::find_if(readyQueue_.begin(), readyQueue_.end(),
+                           [priority](const Process& p) { return priority > p.priority; });
+    readyQueue_.insert(it, std::move(proc));
+    processStates_[pid] = ProcessState::READY;
+    cv_.notify_one();
+}
+
+std::optional<ProcessState> CoreSystem::getProcessState(int pid) const {
+    std::lock_guard<std::mutex> lock(queueMutex_);
+    auto it = processStates_.find(pid);
+    if (it != processStates_.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+void CoreSystem::schedulerLoop() {
+    while (true) {
+        Process proc;
+        {
+            std::unique_lock<std::mutex> lock(queueMutex_);
+            cv_.wait(lock, [this] { return !running_ || !readyQueue_.empty(); });
+            if (!running_ && readyQueue_.empty()) {
+                break; // No more work and scheduler stopped.
+            }
+            proc = std::move(readyQueue_.front());
+            readyQueue_.pop_front();
+            proc.state = ProcessState::RUNNING;
+            processStates_[proc.pid] = proc.state;
+        }
+
+        if (proc.task) {
+            proc.task();
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(queueMutex_);
+            proc.state = ProcessState::TERMINATED;
+            processStates_[proc.pid] = proc.state;
+        }
+    }
+}
+
+} // namespace trinity
+

--- a/src/core/CoreSystem.hpp
+++ b/src/core/CoreSystem.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include "process/ProcessState.hpp"
+
+namespace trinity {
+
+/**
+ * Basic representation of a process in the system. Each process contains an
+ * identifier, its current state and the task to execute when scheduled.
+ */
+struct Process {
+    int pid{0};
+    int priority{0};
+    ProcessState state{ProcessState::NEW};
+    std::string name;
+    std::function<void()> task; // Work the process should perform
+};
+
+/**
+ * CoreSystem provides a tiny cooperative scheduler. Processes can be added to
+ * a ready queue and will be executed sequentially by a background thread.
+ */
+class CoreSystem {
+public:
+    CoreSystem();
+    ~CoreSystem();
+
+    /** Initialize system resources. */
+    void initialize();
+
+    /** Start the scheduler thread. */
+    void start();
+
+    /** Stop the scheduler thread and wait for completion. */
+    void stop();
+
+    /**
+     * Add a new process to the ready queue.
+     * @param task     Work the process should perform
+     * @param priority Larger values run sooner
+     * @param name     Human readable name for diagnostics
+     */
+    void addProcess(std::function<void()> task, int priority = 0, std::string name = "");
+
+    /** Query the state of a process by PID. */
+    std::optional<ProcessState> getProcessState(int pid) const;
+
+private:
+    /** Scheduler loop executed on a dedicated thread. */
+    void schedulerLoop();
+
+    std::deque<Process> readyQueue_;   ///< Queue of processes awaiting execution.
+    std::thread schedulerThread_;      ///< Thread running the scheduler.
+    mutable std::mutex queueMutex_;    ///< Protects access to the ready queue.
+    std::condition_variable cv_;       ///< Notifies scheduler of new work.
+    bool running_{false};              ///< Indicates if the scheduler is active.
+    int nextPid_{1};                   ///< Simple PID generator.
+    std::unordered_map<int, ProcessState> processStates_; ///< Tracks state by PID.
+};
+
+} // namespace trinity
+

--- a/src/process/ProcessInfo.hpp
+++ b/src/process/ProcessInfo.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+namespace trinity {
+
+/**
+ * Enumeration describing available process information fields.
+ * These values can be used to query or set attributes on a process.
+ */
+enum class ProcessInfo : std::uint8_t {
+    PID,        ///< Unique process identifier
+    PRIORITY,   ///< Scheduling priority
+    STATE,      ///< Current state of the process
+    NAME        ///< Human readable name
+};
+
+} // namespace trinity
+

--- a/src/process/ProcessState.hpp
+++ b/src/process/ProcessState.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace trinity {
+
+/**
+ * Enumeration of possible states a process can be in.
+ */
+enum class ProcessState {
+    NEW,      ///< Process has been created but not yet scheduled.
+    READY,    ///< Process is ready to run.
+    RUNNING,  ///< Process is currently executing.
+    WAITING,  ///< Process is waiting on I/O or another event.
+    TERMINATED ///< Process has finished execution.
+};
+
+} // namespace trinity
+


### PR DESCRIPTION
## Summary
- extend `Process` to include priority and name
- maintain process state map with ability to query state
- insert processes into ready queue ordered by priority

## Testing
- `g++ -std=c++17 -pthread -I./src -c src/core/CoreSystem.cpp -o CoreSystem.o`


------
https://chatgpt.com/codex/tasks/task_e_68a359381ed88333a5c613f92e7eaf8a