### PR TITLE
Add process and memory enum definitions

### DIFF
--- a/src/memory/MemoryEnums.hpp
+++ b/src/memory/MemoryEnums.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace trinity {
+
+// Permissions for a region of memory. These can be combined as bit flags.
+enum class MemoryPermission : std::uint8_t {
+    NONE  = 0,
+    READ  = 1 << 0,
+    WRITE = 1 << 1,
+    EXEC  = 1 << 2
+};
+
+// High level classification of memory usage.
+enum class MemoryType {
+    CODE = 0,
+    DATA = 1,
+    STACK = 2,
+    HEAP = 3,
+    SHARED = 4,
+    OTHER = 5
+};
+
+// Continuous region of memory with associated metadata.
+struct MemoryRegion {
+    std::uintptr_t start = 0;      // Starting address
+    std::uintptr_t end = 0;        // End address (exclusive)
+    MemoryPermission permission = MemoryPermission::NONE;
+    MemoryType type = MemoryType::OTHER;
+};
+
+// Logical grouping of memory regions such as a module or allocation.
+struct MemorySegment {
+    std::string name;                    // Identifier for the segment
+    std::vector<MemoryRegion> regions;   // Regions belonging to this segment
+};
+
+} // namespace trinity
+

--- a/src/process/ProcessEnums.hpp
+++ b/src/process/ProcessEnums.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+namespace trinity {
+
+// Represents the lifecycle state of a process in the system.
+enum class ProcessState {
+    NEW = 0,       // Process has been created but not yet scheduled
+    READY = 1,     // Ready to run and waiting for CPU time
+    RUNNING = 2,   // Currently executing on the CPU
+    BLOCKED = 3,   // Waiting on I/O or another resource
+    TERMINATED = 4 // Finished execution
+};
+
+// Priority hint for the scheduler when deciding which process to run.
+enum class ProcessPriority {
+    LOW = 0,
+    NORMAL = 1,
+    HIGH = 2,
+    CRITICAL = 3
+};
+
+// Scheduling policy the operating system uses for this process.
+enum class SchedulingPolicy {
+    FIFO = 0,        // First-in first-out
+    ROUND_ROBIN = 1, // Time-sliced round robin
+    PRIORITY = 2     // Priority based scheduling
+};
+
+} // namespace trinity
+

--- a/src/process/ProcessInfo.hpp
+++ b/src/process/ProcessInfo.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+
+#include "ProcessEnums.hpp"
+
+namespace trinity {
+
+// Basic information about a process.
+struct ProcessInfo {
+    int pid = 0;                 // Process identifier
+    int parent_pid = 0;          // Parent process identifier
+    std::string name;            // Human-readable name
+    ProcessState state = ProcessState::NEW;
+    ProcessPriority priority = ProcessPriority::NORMAL;
+    SchedulingPolicy policy = SchedulingPolicy::FIFO;
+};
+
+} // namespace trinity
+


### PR DESCRIPTION
## Summary
- Define ProcessState, ProcessPriority and SchedulingPolicy enums for processes
- Introduce ProcessInfo struct mirroring Python dataclass
- Add MemoryPermission, MemoryType enums and memory region/segment structs

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68a36971b5a48333873133cfc25cebaf